### PR TITLE
Remove mv command that breaks build

### DIFF
--- a/bin/setup_ci_elixir
+++ b/bin/setup_ci_elixir
@@ -11,9 +11,6 @@ ELIXIR_CACHE_KEY=kiex-elixir-$ELIXIR_VSN
 
 if cache has_key "$ELIXIR_CACHE_KEY"; then
   cache restore $ELIXIR_CACHE_KEY
-  # TODO home/semaphore? try to cache and restore /home not home
-  mv home/semaphore/.kiex/elixirs/elixir-$ELIXIR_VSN $HOME/.kiex/elixirs
-  mv home/semaphore/.kiex/elixirs/elixir-$ELIXIR_VSN.env $HOME/.kiex/elixirs
 else
   kiex install $ELIXIR_VSN
   cache store $ELIXIR_CACHE_KEY $HOME/.kiex/elixirs


### PR DESCRIPTION
Hello, 

I noticed that when I run this through semaphore I get this error:
```
bin/setup_ci_elixir
--
  | Key kiex-elixir-1.8.1 exists in the cache store.
  | HIT: kiex-elixir-1.8.1, using key kiex-elixir-1.8.1
  | Restored: home/semaphore/.kiex/elixirs/
  | mv: cannot move 'home/semaphore/.kiex/elixirs/elixir-1.8.1' to '/home/semaphore/.kiex/elixirs/elixir-1.8.1': Directory not empty
  | exit code: 1 duration: 1s
  | export SEMAPHORE_JOB_RESULT=failed
  | exit code: 0 duration: 0s
  | Job Finished
```

I believe it is fine to remove `mv` since it appears that the cache restores it in the right place.